### PR TITLE
Update GNOME runtime to 47

### DIFF
--- a/io.frama.tractor.carburetor.json
+++ b/io.frama.tractor.carburetor.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.frama.tractor.carburetor",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "carburetor",
   "sdk-extensions": [


### PR DESCRIPTION
Hi, 
this PR just bumps the GNOME runtime to 47, as 45 is outdated by now. I have been using this on aarch64 without problems.
Hope it helps! :slightly_smiling_face: 